### PR TITLE
Add fp/syn lib-table files

### DIFF
--- a/fp-lib-table
+++ b/fp-lib-table
@@ -1,0 +1,3 @@
+(fp_lib_table
+  (lib (name 3x3pot)(type KiCad)(uri ${KIPRJMOD}/footprints/3x3pot.pretty)(options "")(descr ""))
+)

--- a/sym-lib-table
+++ b/sym-lib-table
@@ -1,0 +1,3 @@
+(sym_lib_table
+  (lib (name ea3036c)(type Legacy)(uri ${KIPRJMOD}/symbols/ea3036c.lib)(options "")(descr ""))
+)


### PR DESCRIPTION
By having those files, the footprint and symbol libraries are
automatically imported as a project specific libs making everything
working out of the box.